### PR TITLE
Update to scichart js 3.2.549

### DIFF
--- a/src/SciChartBlazor/DataSeries/DataSeriesBase.cs
+++ b/src/SciChartBlazor/DataSeries/DataSeriesBase.cs
@@ -44,20 +44,23 @@ public abstract class DataSeriesBase
 
         switch (typeAttribute?.GetDataType())
         {
-            case DataSeriesType.XyData:
-                {
-                    output.XyData = (DataSeriesBase)this;
+            case DataSeriesType.Xy:
+				{
+					output.Type = DataSeriesType.Xy;
+					output.Options = (DataSeriesBase)this;
                     break;
                 }
-            case DataSeriesType.XyyData:
+            case DataSeriesType.Xyy:
                 {
-                    output.XyyData = (DataSeriesBase)this;
-                    break;
+					output.Type = DataSeriesType.Xyy;
+					output.Options = (DataSeriesBase)this;
+					break;
                 }
-            case DataSeriesType.XyzData:
+            case DataSeriesType.Xyz:
                 {
-                    output.XyzData = (DataSeriesBase)this;
-                    break;
+					output.Type = DataSeriesType.Xyz;
+					output.Options = (DataSeriesBase)this;
+					break;
                 }
         }
 
@@ -74,10 +77,7 @@ public abstract class DataSeriesBase
     [Serializable]
     private class jsonObject
     {
-        public DataSeriesBase? XyData { get; set; } = null;
-
-        public DataSeriesBase? XyyData { get; set; } = null;
-
-        public DataSeriesBase? XyzData { get; set; } = null;
+	    public DataSeriesType? Type { get; set; } = null;
+        public DataSeriesBase? Options { get; set; } = null;
     }
 }

--- a/src/SciChartBlazor/DataSeries/XyDataSeries.cs
+++ b/src/SciChartBlazor/DataSeries/XyDataSeries.cs
@@ -6,7 +6,7 @@
 /// <typeparam name="TX">The type of the x.</typeparam>
 /// <typeparam name="TY">The type of the y.</typeparam>
 /// <seealso cref="SciChartBlazor.DataSeries.DataSeriesBase" />
-[SciChartDataSeries(DataSeriesType.XyData)]
+[SciChartDataSeries(DataSeriesType.Xy)]
 public class XyDataSeries<TX,TY> : DataSeriesBase
 {
     /// <summary>

--- a/src/SciChartBlazor/Enums.cs
+++ b/src/SciChartBlazor/Enums.cs
@@ -215,9 +215,9 @@ public enum NumericFormat
 /// </summary>
 public enum DataSeriesType
 {
-    XyData,
-    XyyData,
-    XyzData
+    Xy,
+    Xyy,
+    Xyz
 }
 
 public enum AxisType

--- a/src/SciChartBlazor/RenderableSeries/FastBandRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastBandRenderableSeries.cs
@@ -27,7 +27,7 @@ public class FastBandRenderableSeries<TX, TY1, TY2> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyyData)]
+    [SciChartDataSeries(DataSeriesType.Xyy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/FastBubbleRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastBubbleRenderableSeries.cs
@@ -26,7 +26,7 @@ public class FastBubbleRenderableSeries<TX, TY, TZ> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyzData)]
+    [SciChartDataSeries(DataSeriesType.Xyz)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/FastColumnRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastColumnRenderableSeries.cs
@@ -27,7 +27,7 @@ public class FastColumnRenderableSeries<TX, TY> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/FastImpulseRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastImpulseRenderableSeries.cs
@@ -34,7 +34,7 @@ public class FastImpulseRenderableSeries<TX, TY> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/FastLineRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastLineRenderableSeries.cs
@@ -35,6 +35,6 @@ public class FastLineRenderableSeries<TX, TY> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 }

--- a/src/SciChartBlazor/RenderableSeries/FastMountainRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/FastMountainRenderableSeries.cs
@@ -27,7 +27,7 @@ public class FastMountainRenderableSeries<TX, TY> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/SplineBandRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/SplineBandRenderableSeries.cs
@@ -52,7 +52,7 @@ public class SplineBandRenderableSeries<TX, TY1, TY2> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyyData)]
+    [SciChartDataSeries(DataSeriesType.Xyy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/SplineLineRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/SplineLineRenderableSeries.cs
@@ -27,7 +27,7 @@ public class SplineLineRenderableSeries<TX, TY> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/SplineMountainRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/SplineMountainRenderableSeries.cs
@@ -52,7 +52,7 @@ public class SplineMountainRenderableSeries<TX, TY> : LineRenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
 	public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/StackedColumnRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/StackedColumnRenderableSeries.cs
@@ -35,7 +35,7 @@ public class StackedColumnRenderableSeries<TX, TY> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/StackedMountainRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/StackedMountainRenderableSeries.cs
@@ -42,7 +42,7 @@ public class StackedMountainRenderableSeries<TX, TY> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/UniformContoursRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/UniformContoursRenderableSeries.cs
@@ -26,7 +26,7 @@ public class UniformContoursRenderableSeries<TX, TY, TZ> : RenderableSeriesBase
     /// <value>
     /// The data series.
     /// </value>
-    [SciChartDataSeries(DataSeriesType.XyzData)]
+    [SciChartDataSeries(DataSeriesType.Xyz)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>

--- a/src/SciChartBlazor/RenderableSeries/XyScatterRenderableSeries.cs
+++ b/src/SciChartBlazor/RenderableSeries/XyScatterRenderableSeries.cs
@@ -18,7 +18,7 @@ public class XyScatterRenderableSeries<TX, TY> : RenderableSeriesBase
 
     /// <summary>Gets the data series.</summary>
     /// <value>The data series.</value>
-    [SciChartDataSeries(DataSeriesType.XyData)]
+    [SciChartDataSeries(DataSeriesType.Xy)]
     public override DataSeriesBase DataSeries { get; }
 
     /// <summary>Initializes a new instance of the <see cref="XyScatterRenderableSeries{TX, TY}" /> class.</summary>

--- a/src/SciChartBlazor/SciChart/ScichartElementBase.cs
+++ b/src/SciChartBlazor/SciChart/ScichartElementBase.cs
@@ -125,17 +125,17 @@ public abstract class SciChartElementBase
                             output.Options.Add(ConvertToCamelCase(property.Name), (int)value);
                             break;
                         }
-                    case DataSeriesType.XyData:
+                    case DataSeriesType.Xy:
                         {
                             output.XyData = (DataSeriesBase)value;
                             break;
                         }
-                    case DataSeriesType.XyyData:
+                    case DataSeriesType.Xyy:
                         {
                             output.XyyData = (DataSeriesBase)value;
                             break;
                         }
-                    case DataSeriesType.XyzData:
+                    case DataSeriesType.Xyz:
                         {
                             output.XyzData = (DataSeriesBase)value;
                             break;

--- a/src/SciChartBlazor/wwwroot/SciChart/package-lock.json
+++ b/src/SciChartBlazor/wwwroot/SciChart/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "scichart": "^3.2.461"
+        "scichart": "^3.2.549"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^9.1.0",
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/scichart": {
-      "version": "3.2.461",
-      "resolved": "https://registry.npmjs.org/scichart/-/scichart-3.2.461.tgz",
-      "integrity": "sha512-EiAcso4R12JI0etkbhdGc2VE8ZY92EIHK9865jpmXHpAVCnV/uNL3pDu6y4+0+unTg5dMG/15YO2M9nI9S3vzQ=="
+      "version": "3.2.549",
+      "resolved": "https://registry.npmjs.org/scichart/-/scichart-3.2.549.tgz",
+      "integrity": "sha512-syNy3PXP5Klaypwop6BlRhvXKzCHot0mTUUDFA6VAzsAnhYqs7vwDb8H3/F7DSLHiWI4f8q/deDV+Yuh4vsFOw=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -5680,9 +5680,9 @@
       }
     },
     "scichart": {
-      "version": "3.2.461",
-      "resolved": "https://registry.npmjs.org/scichart/-/scichart-3.2.461.tgz",
-      "integrity": "sha512-EiAcso4R12JI0etkbhdGc2VE8ZY92EIHK9865jpmXHpAVCnV/uNL3pDu6y4+0+unTg5dMG/15YO2M9nI9S3vzQ=="
+      "version": "3.2.549",
+      "resolved": "https://registry.npmjs.org/scichart/-/scichart-3.2.549.tgz",
+      "integrity": "sha512-syNy3PXP5Klaypwop6BlRhvXKzCHot0mTUUDFA6VAzsAnhYqs7vwDb8H3/F7DSLHiWI4f8q/deDV+Yuh4vsFOw=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/src/SciChartBlazor/wwwroot/SciChart/package.json
+++ b/src/SciChartBlazor/wwwroot/SciChart/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "scichart": "^3.2.461"
+    "scichart": "^3.2.549"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^9.1.0",


### PR DESCRIPTION
Proposal to update to Scichart Js 3.2.549.
The only changes that I found impacted the package was that the update changes the expected serialization of the DataSeries.